### PR TITLE
Fix batch import

### DIFF
--- a/src/exportCollection/index.ts
+++ b/src/exportCollection/index.ts
@@ -1,9 +1,6 @@
 import * as admin from 'firebase-admin';
 import * as fs from 'fs-extra';
-import * as csv from 'csvtojson';
 import * as _ from 'lodash';
-import { processFile as processXlsx } from 'excel-as-json';
-
 
 const db = admin.firestore();
 let args;

--- a/src/exportCollection/index.ts
+++ b/src/exportCollection/index.ts
@@ -1,0 +1,76 @@
+import * as admin from 'firebase-admin';
+import * as fs from 'fs-extra';
+import * as csv from 'csvtojson';
+import * as _ from 'lodash';
+import { processFile as processXlsx } from 'excel-as-json';
+
+
+const db = admin.firestore();
+let args;
+
+export const execute = async (file: string, collectionPaths: string[], options) => {    
+    args = options;
+    let json = {};
+
+    // If no collection arguments, select all root collections
+    if (collectionPaths.length === 0) {
+        console.log('Fetching root collections...');
+        collectionPaths = await db.getCollections().then(colls => colls.map(coll => coll.path));    
+    }
+
+    // Get selected collections
+    getCollections(collectionPaths)
+        .then(collections => {            
+            return fs.writeJson(file, collections);
+        })
+        .then(() => {
+            console.log('JSON file written. Download was a success!');
+        })
+        .catch(err => {
+            console.log('Failure: ', err);
+        });
+
+}
+
+function getCollections(paths): Promise<any> {
+    return new Promise(async (resolve, reject) =>{
+        let collections = {};
+
+        // A heavily nested sub-collection-tree will cause a parallel promise explosion,
+        // so we rather request them sequentially. Might be worth allowing parallel
+        // recursion upon user request, for smaller trees and faster execution.
+        for (const path of paths) {
+            const collection = await getCollection(path);
+            _.assign(collections, collection);
+        }
+
+        resolve(collections);
+    });    
+} 
+
+function getCollection(path): Promise<any> {
+    let collection = {};
+    return db.collection(path).get().then( async snaps => {
+        for (let snap of snaps.docs) {
+            let doc = { [snap.id]: snap.data() };
+
+            // log if requested
+            args.log && console.log(snap.ref.path);
+
+            // process sub-collections
+            if (args.subcollections) {
+                const subCollPaths = await snap.ref.getCollections().then(colls => colls.map(coll => coll.path));
+                if (subCollPaths.length) {
+                    const subCollections = await getCollections(subCollPaths);
+                    _.assign(doc, subCollections);
+                }
+            }
+
+            _.assign(collection, doc);
+        }
+    }).then(() =>{
+        const collId = path.split('/').pop();
+        const collPath = `${args.collectionPrefix}:${collId}`;
+        return ({[collPath]: collection });
+    });            
+}   

--- a/src/exportCollection/index.ts
+++ b/src/exportCollection/index.ts
@@ -55,10 +55,10 @@ function getCollection(path): Promise<any> {
             let doc = { [snap.id]: snap.data() };
 
             // log if requested
-            args.log && console.log(snap.ref.path);
+            args.verbose && console.log(snap.ref.path);
 
             // process sub-collections
-            if (args.subcollections) {
+            if (args.subcolls) {
                 const subCollPaths = await snap.ref.getCollections().then(colls => colls.map(coll => coll.path));
                 if (subCollPaths.length) {
                     const subCollections = await getCollections(subCollPaths);
@@ -70,7 +70,7 @@ function getCollection(path): Promise<any> {
         }
     }).then(() =>{
         const collId = path.split('/').pop();
-        const collPath = `${args.collectionPrefix}:${collId}`;
+        const collPath = `${args.collPrefix}:${collId}`;
         return ({[collPath]: collection });
     });            
 }   

--- a/src/importCollection/index.ts
+++ b/src/importCollection/index.ts
@@ -1,22 +1,20 @@
 import * as admin from 'firebase-admin';
 import * as fs from 'fs-extra';
-import * as csv from 'csvtojson';
 import * as _ from 'lodash';
+import * as csv from 'csvtojson';
 import { processFile as processXlsx } from 'excel-as-json';
 
 
 const db = admin.firestore();
-const batch = db.batch();
+let batch = db.batch();
 let batchSetCount = 0;
+let totalSetCount = 0;
 let args;
 
 
 export const execute = async (file, collection, options) => {    
     args = options;
     if( args.dryRun ) args.verbose = true;
-
-    console.log('Chunk: ' + args.chunk);
-    process.exit(1);
 
     try {
     
@@ -37,15 +35,15 @@ export const execute = async (file, collection, options) => {
             throw "Unknown file extension. Supports .json, .csv or .xlsx!";
         }
     
-        await writeCollection(data, collection);
-    
-        // Commit the batch
-        if (args.dryRun) {
-            console.log("Dry-run complete, Firestore was not updated!");
-        } else {
-            batchCommit();
-            console.log("Firestore updated. Import was a success!");
-        }
+        await writeCollection(data, collection);    
+
+        // Final Batch commit and completion message.
+        await batchCommit(false);
+        console.log(args.dryRun
+            ? 'Dry-Run complete, Firestore was not updated.'
+            : 'Import success, Firestore updated!'
+        );
+        console.log(`Total documents: ${totalSetCount}`);
     
     } catch (error) {
         console.log("Import failed!", error);
@@ -58,44 +56,57 @@ async function batchSet(ref: FirebaseFirestore.DocumentReference, item, options)
     // Log if requested
     args.verbose && console.log(ref.path);    
 
-    // Set the Data
+    // Set the Document Data
+    ++totalSetCount;
     await batch.set(ref, item, options);
 
     // Commit batch on chunk size
-    if (!args.dryRun && (++batchSetCount % args.chunk === 0)) {
+    if (++batchSetCount % args.chunk === 0) {
         await batchCommit()
     }
 }
 
-async function batchCommit() {
+async function batchCommit(recycle:boolean = true) {
+    // Nothing to commit
+    if (!batchSetCount) return;
+    // Don't commit on Dry Run
+    if (args.dryRun) return;
+
     // Log if requested
     args.verbose && console.log('Committing write batch...')
 
     // Commit batch
     await batch.commit();    
+
+    // Get a new batch
+    if (recycle) {
+        batch = db.batch();
+        batchSetCount = 0;
+    }
 }
 
 function writeCollection(data:JSON, path: string): Promise<any> {
-    return new Promise((resolve, reject) => {
-        const mode = (data instanceof Array) ? 'array' : 'object';
+    return new Promise(async (resolve, reject) => {
         const colRef = db.collection(path);
-        _.forEach(data, async (item:object, id) => {
+        const mode = (data instanceof Array) ? 'array' : 'object';
+        for ( let [id, item] of Object.entries(data)) {
+            
             // doc-id preference: object key, invoked --id option, auto-id
             id = (mode === 'object') ? id : (args.id && _.hasIn(item, args.id)) ? item[args.id].toString() : colRef.doc().id;
             
             // Look for and process sub-collections
             const subColKeys = Object.keys(item).filter(k => k.startsWith(args.collPrefix+':'));
-            await subColKeys.forEach(async (key:string) => {
+            for ( let key of subColKeys ) {
                 const subPath = [path, id, key.slice(args.collPrefix.length + 1) ].join('/');
                 await writeCollection(item[key], subPath);
                 delete item[key];
-            });
+            }
             
             // set document data into path/id
             const docRef = colRef.doc(id);
             await batchSet(docRef, item, { merge: !!(args.merge) });
 
-        });
+        }
         
         resolve();
     });

--- a/src/importCollection/index.ts
+++ b/src/importCollection/index.ts
@@ -1,0 +1,111 @@
+import * as admin from 'firebase-admin';
+import * as fs from 'fs-extra';
+import * as csv from 'csvtojson';
+import * as _ from 'lodash';
+import { processFile as processXlsx } from 'excel-as-json';
+
+
+const db = admin.firestore();
+const batch = db.batch();
+let args;
+
+export const execute = async (file, collection, options) => {    
+    args = options;
+    args.log = !!(args.dryRun);
+
+    try {
+    
+        let data;
+        if (file.endsWith(".json")) {
+            data = await fs.readJSON(file);
+        }
+
+        else if (file.endsWith(".csv")) {
+            data = await readCSV(file);
+        }
+
+        else if (file.endsWith(".xlsx")) {
+            data = await readXLSX(file);
+        }
+
+        else {
+            throw "Unknown file extension. Supports .json, .csv or .xlsx!";
+        }
+    
+        await writeCollection(data, collection);
+    
+        // Commit the batch
+        if (args.dryRun) {
+            console.log("Dry-run complete, Firestore was not updated!");
+        } else {
+            await batch.commit();
+            console.log("Firestore updated. Import was a success!");
+        }
+    
+    } catch (error) {
+        console.log("Import failed!", error);
+    }
+
+
+}
+
+function writeCollection(data:JSON, path: string): Promise<any> {
+    return new Promise((resolve, reject) => {
+        const mode = (data instanceof Array) ? 'array' : 'object';
+        const colRef = db.collection(path);
+        _.forEach(data, async (item:object, id) => {
+            // doc-id preference: object key, invoked --id option, auto-id
+            id = (mode === 'object') ? id : (args.id && _.hasIn(item, args.id)) ? item[args.id].toString() : colRef.doc().id;
+            
+            // Look for and process sub-collections
+            const subColKeys = Object.keys(item).filter(k => k.startsWith(args.subcollectionPrefix+':'));
+            await subColKeys.forEach(async (key:string) => {
+                const subPath = [path, id, key.slice(args.subcollectionPrefix.length + 1) ].join('/');
+                await writeCollection(item[key], subPath);
+                delete item[key];
+            });
+            
+            // set document data into path/id
+            const docRef = colRef.doc(id);
+            batch.set(docRef, item, { merge: !!(args.merge) });
+
+            // log if requested
+            args.log && console.log(docRef.path);
+        });
+        resolve();
+    });
+}
+
+function readCSV(path): Promise<any> {
+    return new Promise((resolve, reject) => {
+        let lineCount = 0;
+
+        csv()
+            .fromFile(path)
+            .on("json", data => {
+                // fired on every row read
+                lineCount++;
+            })
+            .on("end_parsed", data => {
+                console.info(`CSV read complete. ${lineCount} rows parsed.`);
+                resolve(data);
+            })
+            .on("error", err => reject(err));
+    });
+}
+
+function readXLSX(path): Promise<any> {
+    return new Promise((resolve, reject) => {
+        const options = {
+            sheet: args.sheet,
+            isColOriented: args.colOriented ? true : false,
+            omitEmtpyFields: args.omitEmptyFields ? true : false
+        }
+        console.log('Reading XLSX with options', options);
+        processXlsx(path, null, options, (err,data) => {
+            if (err) reject(err);
+            console.info('XLSX read complete.');
+            resolve(data);
+        })
+    });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,14 +83,14 @@ args.command('import')
     }).on('--help', () => {
         console.log(importHelp);
     });
-    
+
 
 // Export options
 args.command('export <file> [collections...]')
     .alias('e')
     .description('Export Firestore collection(s) to a JSON file')
     .option('-s, --subcolls', 'Include sub-collections.')
-    .option('-p, --collection-prefix [prefix]', 'Collection prefix', 'collection')
+    .option('-p, --coll-prefix [prefix]', 'Collection prefix', 'collection')
     .option('-v, --verbose', 'Output traversed document paths')
     .action((file, collections, options) => {
         exportCollection.execute(file, collections, options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ admin.initializeApp({
 
 import * as importCollection from './importCollection';
 import * as exportCollection from './exportCollection';
+import { parse } from 'url';
 
 
 // Help Descriptions
@@ -55,6 +56,13 @@ const exportHelp = [
 ].join('\n').replace(/^/gm, '  ');
 
 
+// Some option helper functions
+
+function parseChunk(v:number) {
+    return _.clamp(v, 1, 500);
+}
+
+
 // Base options
 args.version('0.1.0')
     .description(rootDescription)
@@ -70,6 +78,7 @@ args.command('import')
     .arguments('<file> <collection>')
     .option('-i, --id [field]', 'Field to use for document ID')
     .option('-m, --merge', 'Merge Firestore documents. Default is replace.')
+    .option('-k, --chunk [size]', 'Split upload into batches. Max 500 by Firestore constraints.', parseChunk, 500 ) 
     .option('-p, --coll-prefix [prefix]', '(Sub-)Collection prefix', 'collection')
     .option('')
     .option('-c, --col-oriented', 'XLSX column orientation. Default is row orientation')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
         "sourceMap": true,
         "moduleResolution": "node",
         "lib": [
-            "es2015"
+            // "es2015"
+            "es2017"
         ],
         "types": [
             "node"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,6 @@
         "sourceMap": true,
         "moduleResolution": "node",
         "lib": [
-            // "es2015"
             "es2017"
         ],
         "types": [


### PR DESCRIPTION
Provides `import -k, --chunk` option. Default and Max of 500, Firestore's limit.


