### PR TITLE
Fix to npm run build error and fire-migrate not found error

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Watch the [screencast](https://angularfirebase.com/lessons/import-csv-json-or-ex
 
 - Clone and run `npm install`
 - Download the service account from your Firebase project settings, then save it as `credentials.json` in the project root. 
-- `npm run build` and you're off and running.
+- `npm run build-link` and you're off and running.
 
 ## Import Data to Firestore
 
@@ -22,7 +22,7 @@ Watch the [screencast](https://angularfirebase.com/lessons/import-csv-json-or-ex
 - Omitting [collections...], or specifying root "/" will import all collections.
 
 ```
-import|i [options] <file> [collections...]
+fire-migrate import|i [options] <file> [collections...]
 ```
 
 Options:
@@ -57,7 +57,7 @@ fire-migrate i -m --id docid test.xlsx myCollection
 - Splits CSV/XLSX collections into separate files/sheets with an INDEX.
 
 ```
-export|e [options] <file> [collections...]
+fire-migrate export|e [options] <file> [collections...]
 ```
 
 Options:

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "@types/csvtojson": "^1.1.5",
     "@types/fs-extra": "^5.0.1",
     "@types/lodash": "^4.14.106",
-    "@types/node": "^10.5.7",
-    "typescript": "^3.0.1"
+    "@types/node": "^12.12.7",
+    "typescript": "^3.2.2"
   },
   "dependencies": {
     "commander": "^2.15.1",


### PR DESCRIPTION
Resolves issues #32 and #25 
Typescript needed to be updated along with the @types/node
README updated to make it clear that npm run build-link will find fire-migrate (and also, let's put fire-migrate in the command description itself.

I have a lot of appreciation for this code, it is incredibly useful.